### PR TITLE
Add mdk run option to to list what scripts are available

### DIFF
--- a/lib/moodle.py
+++ b/lib/moodle.py
@@ -25,6 +25,7 @@ http://github.com/FMCorz/mdk
 import os
 import re
 import shutil
+import glob
 
 from tools import debug, process
 from db import DB
@@ -603,6 +604,22 @@ class Moodle(object):
             result = self.cli('mdkrun.php', **kwargs)
             os.remove(dest)
             return result[0]
+
+    def listScripts(self):
+        """List scripts available """
+        directories = ['~/.moodle-sdk']
+        if C.get('dirs.moodle') != None:
+            directories.insert(0, C.get('dirs.moodle'))
+        directories.append('/etc/moodle-sdk')
+        directories.append(os.path.join(os.path.dirname(__file__), '..'))
+
+        # Loop over each directory in order of preference.
+        for directory in directories:
+            path = os.path.join(directory, 'scripts')
+            if os.path.exists(path):
+                os.chdir(path)
+                for files in glob.glob('*.php'):
+                    print files
 
     def update(self, remote = None):
         """Update the instance from the remote"""

--- a/moodle-run.py
+++ b/moodle-run.py
@@ -54,7 +54,10 @@ if len(Mlist) < 1:
 for M in Mlist:
     debug('Running \'%s\' on \'%s\'' % (args.script, M.get('identifier')))
     try:
-        M.runScript(args.script, stderr=None, stdout=None)
+        if args.script == 'list':
+            M.listScripts()
+        else:
+            M.runScript(args.script, stderr=None, stdout=None)
     except Exception as e:
         debug('Error while running the script on %s' % M.get('identifier'))
         debug(e)


### PR DESCRIPTION
This is wrong on so many levels:
- The business logic is in the moodle class, but the logic is not
  related to a Moodle instance
- The argument to list scripts should be added as a proper one, not overided
  the value of 'script'
- The code which gets the list of directories structure should be
  abstracted so it can be used by listScripts and runScript rathe than
  duplicated
- We probably should list the path as well as the script name
- This is some of my first python code, so I don't even know if i'm
  using the right methods

So whatever you do, DON'T merge this!
