### PR TITLE
Add quotes around incorrect command name

### DIFF
--- a/moodle
+++ b/moodle
@@ -73,11 +73,11 @@ BIN=`resolve $COMMAND`
 
 if [ $? == 1 ]
 then
-    echo "Unknown Moodle command $1..."
+    echo "Unknown Moodle command '$1'..."
     exit 1
 elif [ ! -x "$BIN" ]
 then
-    echo "Permission denied. $BIN is not executable."
+    echo "Permission denied. '$BIN' is not executable."
     exit 1
 fi
 


### PR DESCRIPTION
Earlier, I kept typing the wrong command name:

```
$ mdk script dev.php
Unknown Moodle command script...
```

And I kept trying different variations, not realising the problem was that I was calling `mdk script` rather than `mdk run`. I thought it was just the error message from `mdk script`. I think i'd have noticed the problem earlier  it'd be clearer to quote the text. I've done this before too e.g. git does this:

```
$ git foo
git: 'foo' is not a git command. See 'git --help'.

Did you mean this?
    log
```
