### PR TITLE
Stop disabling combo loading for YUI in dev.php

### DIFF
--- a/scripts/dev.php
+++ b/scripts/dev.php
@@ -43,9 +43,6 @@ mdk_set_config('themedesignermode', 1);
 // Do not cache JavaScript.
 mdk_set_config('cachejs', 0);
 
-// Do not use YUI combo loading.
-mdk_set_config('yuicomboloading', 0);
-
 // Disable modintro for lazy devs.
 mdk_set_config('requiremodintro', 0, 'book');
 mdk_set_config('requiremodintro', 0, 'folder');


### PR DESCRIPTION
The YUI combo loading setting shouldn't be used unless you're actively
developing JavaScript.

Ideally we should make this part of the js command instead.

I've left it in the undev because otherwise it won't be unset by anyone who
has run dev before upgrading.
