### PR TITLE
Add sourcemap support using lessc to css command

### DIFF
--- a/config-dist.json
+++ b/config-dist.json
@@ -169,6 +169,8 @@
     "java": "/usr/bin/java",
     // Path to recess
     "recess": "/usr/local/bin/recess",
+    // Path to lessc
+    "lessc": "/usr/local/bin/lessc",
 
     // Debug level of MDK. 'debug', 'info', 'warning', 'error' or 'critical'.
     "debug": "info",

--- a/lib/commands/css.py
+++ b/lib/commands/css.py
@@ -62,6 +62,14 @@ class CssCommand(Command):
             }
         ),
         (
+            ['-d', '--debug'],
+            {
+                'action': 'store_true',
+                'dest': 'debug',
+                'help': 'produce an unminified debugging version with source maps'
+            }
+        ),
+        (
             ['-w', '--watch'],
             {
                 'action': 'store_true',
@@ -113,6 +121,9 @@ class CssCommand(Command):
             if args.compile:
                 logging.info('Compiling theme \'%s\' on %s' % (args.theme, M.get('identifier')))
                 processor = css.Css(M)
+                processor.setDebug(args.debug)
+                if args.debug:
+                    processor.setCompiler('lessc')
                 processor.compile(theme=args.theme, sheets=args.sheets)
 
         # Setting up watchdog. This code should be improved when we will have more than a compile option.


### PR DESCRIPTION
Although Moodle doesn't officially support lessc as a compiler, it is very
useful for development because it supports source mapping whilst recess
does not.
