### PR TITLE
Respect the 'path' config when setting $CFG->sessioncookiepath

### DIFF
--- a/lib/moodle.py
+++ b/lib/moodle.py
@@ -419,7 +419,10 @@ class Moodle(object):
         configFile = os.path.join(self.path, 'config.php')
         os.chmod(configFile, 0666)
         try:
-            self.addConfig('sessioncookiepath', '/%s/' % self.identifier)
+            if C.get('path') != '' and C.get('path') != None:
+                self.addConfig('sessioncookiepath', '/%s/%s/' % (C.get('path'), self.identifier))
+            else:
+                self.addConfig('sessioncookiepath', '/%s/' % self.identifier)
         except InstallException:
             logging.warning('Could not append $CFG->sessioncookiepath to config.php')
 


### PR DESCRIPTION
Setups using the `path` config ended with invalid `$CFG->sessioncookiepath` set
in config.php (always expecting the moodle is in the root). Moodle core itself
has checks for this so the value set in config.php was ignored in that case.
