### PR TITLE
Add support for globally defined forced $CFG

### DIFF
--- a/mdk/moodle.py
+++ b/mdk/moodle.py
@@ -430,6 +430,16 @@ class Moodle(object):
         except InstallException:
             logging.warning('Could not append $CFG->sessioncookiepath to config.php')
 
+        # Add forced $CFG to the config.php if some are globally defined
+        forceCfg = C.get('forceCfg')
+        if isinstance(forceCfg, dict):
+            logging.info('Setting up forced $CFG variables in the config.php ...')
+            for cfgKey, cfgValue in forceCfg.iteritems():
+                try:
+                    self.addConfig(cfgKey, cfgValue)
+                except InstallException:
+                    logging.warning('Could not append $CFG->%s to config.php' % cfgKey)
+
         self.reload()
 
     def isInstalled(self):


### PR DESCRIPTION
There are some additional $CFG variables that the mdk user may want to always
set in all config.php created. In my case, it is $CFG->divertallemailsto to
prevent accidental mails sent out from my local installations.

The patch adds support for the new mdk-config items grouped under `forceCfg`.
If the setting forceCfg.foobar is found, it's value will be put into
$CFG->foobar right after the installation process.
