### PR TITLE
Add support for optional wording.prefixDbname setting

### DIFF
--- a/config-dist.json
+++ b/config-dist.json
@@ -33,6 +33,8 @@
 
     // Database access
     "db": {
+        // Name prefix for all databases created by mdk. Affects the database name only, not the tables.
+        "namePrefix": "",
         "mysqli": {
             "host": "localhost",
             "port": "3306",

--- a/lib/commands/create.py
+++ b/lib/commands/create.py
@@ -183,6 +183,10 @@ class CreateCommand(Command):
 
             # Checking database
             dbname = re.sub(r'[^a-zA-Z0-9]', '', name).lower()[:28]
+            prefixDbname = self.C.get('db.namePrefix')
+            if prefixDbname == None:
+                prefixDbname = '';
+            dbname = prefixDbname + dbname
             db = DB(engine, self.C.get('db.%s' % engine))
             dropDb = False
             if db.dbexists(dbname):

--- a/lib/moodle.py
+++ b/lib/moodle.py
@@ -384,6 +384,10 @@ class Moodle(object):
             raise InstallException('Cannot install instance without knowing where the data directory is')
         if dbname == None:
             dbname = re.sub(r'[^a-zA-Z0-9]', '', self.identifier).lower()[:28]
+            prefixDbname = C.get('db.namePrefix')
+            if prefixDbname == None:
+                prefixDbname = '';
+            dbname = prefixDbname + dbname
         if engine == None:
             engine = C.get('defaultEngine')
         if fullname == None:


### PR DESCRIPTION
Currently, the default database name is the same as the Moodle instance's name.
This is suboptimal for development setups where the database engine is used for
other projects as well (Moodle developer can easily have Mahara or Mediawiki
databases present as well, for example).

I believe it's a good idea to make it clear that certain database is under
mdk's control. Having a prefix (such as `mdk_`) seems to work well.
