### PR TITLE
Add pretty format to Behat output

### DIFF
--- a/mdk/commands/behat.py
+++ b/mdk/commands/behat.py
@@ -236,8 +236,8 @@ class BehatCommand(Command):
                 cmd.append('--tags ~@javascript')
 
             if args.faildump:
-                cmd.append('--format="progress,progress,html,failed"')
-                cmd.append('--out=",{0}/progress.txt,{0}/status.html,{0}/failed.txt"'.format(outputDir))
+                cmd.append('--format="progress,progress,pretty,html,failed"')
+                cmd.append('--out=",{0}/progress.txt,{0}/pretty.txt,{0}/status.html,{0}/failed.txt"'.format(outputDir))
 
             cmd.append('--config=%s/behat/behat.yml' % (M.get('behat_dataroot')))
 


### PR DESCRIPTION
As discussed, this outputs a pretty format so that you can see the exact point that a test is in place in the CLI as well as through status.html.
