### PR TITLE
Add testsuite coverage to phpunit

### DIFF
--- a/extra/bash_completion
+++ b/extra/bash_completion
@@ -172,7 +172,7 @@ function _mdk() {
                     OPTS="$(compgen -A file $CUR)"
                     compopt -o nospace
                 else
-                    OPTS="--force --run --testcase --unittest --filter --coverage"
+                    OPTS="--force --run --testcase --unittest --filter --coverage --testsuite"
                     OPTS="$OPTS $(_list_instances)"
                 fi
                 ;;

--- a/mdk/commands/phpunit.py
+++ b/mdk/commands/phpunit.py
@@ -57,6 +57,14 @@ class PhpunitCommand(Command):
             }
         ),
         (
+            ['-s', '--testsuite'],
+            {
+                'default': None,
+                'help': 'testsuite to run',
+                'metavar': 'testsuite'
+            }
+        ),
+        (
             ['-u', '--unittest'],
             {
                 'default': None,
@@ -144,6 +152,7 @@ class PhpunitCommand(Command):
                 'coverage': args.coverage,
                 'filter': args.filter,
                 'testcase': args.testcase,
+                'testsuite': args.testsuite,
                 'unittest': args.unittest
             }
 

--- a/mdk/phpunit.py
+++ b/mdk/phpunit.py
@@ -40,7 +40,7 @@ class PHPUnit(object):
         self._Wp = Wp
         self._M = M
 
-    def getCommand(self, testcase=None, unittest=None, filter=None, coverage=None):
+    def getCommand(self, testcase=None, unittest=None, filter=None, coverage=None, testsuite=None):
         """Get the PHPUnit command"""
         cmd = []
         if self.usesComposer():
@@ -58,6 +58,9 @@ class PHPUnit(object):
             cmd.append(unittest)
         elif filter:
             cmd.append('--filter="%s"' % filter)
+        elif testsuite:
+            cmd.append('--testsuite')
+            cmd.append(testsuite)
 
         return cmd
 


### PR DESCRIPTION
In Moodle, we put all of our test directories into testsuites. For example, the
message/tests directory is defined in the core_message_testsuite testsuite.

Because of our naming scheme for files, we cannot simply pass the directory as
this only looks for files with the suffix Test.php. We can however make use
of the testsuite option to phpunit.

Suites are named as per their frankenstyle component and the complete list
can be found in the generated phpunit.xml configration. Here's an excerpt
for the above example:

```
<testsuite name="core_message_testsuite">
    <directory suffix="_test.php">message/tests</directory>
</testsuite>
```

With this change, it becomes possible to run all tests for an entire
component quickly and easily:

```
mdk phpunit -s core_message_testsuite
```
