### PR TITLE
Check for requiremodintro before attempting to set it to default

### DIFF
--- a/mdk/scripts/undev.php
+++ b/mdk/scripts/undev.php
@@ -101,6 +101,8 @@ $resources = array('book', 'folder', 'imscp', 'page', 'resource', 'url');
 foreach ($resources as $r) {
     $settingpage = $adminroot->locate('modsetting' . $r, true);
     $settings = $settingpage->settings;
-    $default = $settings->requiremodintro->get_defaultsetting();
-    mdk_set_config('requiremodintro', $default, $r);
+    if (isset($settings->requiremodintro)) {
+        $default = $settings->requiremodintro->get_defaultsetting();
+        mdk_set_config('requiremodintro', $default, $r);
+    }
 }


### PR DESCRIPTION
I keep getting:

PHP Notice:  Undefined property: stdClass::$requiremodintro in .../moodle/mdkscriptrun.php on line 104

Notice: Undefined property: stdClass::$requiremodintro in .../moodle/mdkscriptrun.php on line 104
PHP Fatal error:  Call to a member function get_defaultsetting() on a non-object in .../moodle/mdkscriptrun.php on line 104

Fatal error: Call to a member function get_defaultsetting() on a non-object in .../moodle/mdkscriptrun.php on line 104

When running undev. This seems to do the trick