### PR TITLE
Fix precheck command after phpcs renaming and add missing checks.

### DIFF
--- a/mdk/commands/precheck.py
+++ b/mdk/commands/precheck.py
@@ -116,13 +116,15 @@ class PrecheckCommand(Command):
 
         mapping = {
             'phplint': 'PHP Lint',
-            'php': 'PHP coding style',
+            'phpcs': 'PHP coding style',
             'js': 'Javascript',
             'css': 'CSS',
             'phpdoc': 'PHP Doc',
             'commit': 'Commit message',
             'savepoint': 'Update/Upgrade',
-            'thirdparty': 'Third party'
+            'thirdparty': 'Third party',
+            'grunt': 'Grunt',
+            'shifter': 'Shifter'
         }
 
         for key in mapping:


### PR DESCRIPTION
In https://github.com/moodlehq/moodle-local_ci/pull/70 the php code sniffer abbreviation was changed to phpcs. In various other isues we've added more CI checks which are missing from mdk.

Ideally this should be rewritten to output the result of all the checks, regardless of whether they are defined in mdk, but thats for another day.