### PR TITLE
Target minified Selenium download link using LXML, not regex

### DIFF
--- a/mdk/commands/behat.py
+++ b/mdk/commands/behat.py
@@ -31,6 +31,7 @@ from tempfile import gettempdir
 from time import sleep
 from ..command import Command
 from ..tools import process, ProcessInThread, downloadProcessHook, question
+from lxml import html
 
 
 class BehatCommand(Command):
@@ -191,15 +192,16 @@ class BehatCommand(Command):
             logging.info('Attempting to find a download for Selenium')
             url = urllib.urlopen('http://docs.seleniumhq.org/download/')
             content = url.read()
-            selenium = re.search(r'http:[a-z0-9/._-]+selenium-server-standalone-[0-9.]+\.jar', content, re.I)
+            tree = html.fromstring(content)
+            selenium = tree.xpath('//div[@id="mainContent"]/p/a[starts-with(@href, "http://goo.gl/")]')[0].get('href')
             if selenium:
-                logging.info('Downloading Selenium from %s' % (selenium.group(0)))
+                logging.info('Downloading Selenium from %s' % (selenium))
                 if (logging.getLogger().level <= logging.INFO):
-                    urllib.urlretrieve(selenium.group(0), seleniumPath, downloadProcessHook)
+                    urllib.urlretrieve(selenium, seleniumPath, downloadProcessHook)
                     # Force a new line after the hook display
                     logging.info('')
                 else:
-                    urllib.urlretrieve(selenium.group(0), seleniumPath)
+                    urllib.urlretrieve(selenium, seleniumPath)
             else:
                 logging.warning('Could not locate Selenium server to download')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ MySQL-python>=1.2.3
 psycopg2>=2.4.5
 requests>=2.3.0
 watchdog>=0.8.0
+lxml>=3.0.2


### PR DESCRIPTION
It appears that a while back, the maintainers of Selenium shifted to using a Google minified link instead of a direct link to the Selenium server JAR file. This broke mdk behat, which was using a regex based on the JAR file's name.

This pull request represents the use of LXML and XPath to find the correct link. Unfortunately as the source page being scraped is not particularly semantic I don't think there's a better way of doing this at present.