### PR TITLE
Extract Selenium JAR url from Google APIs XML.

### DIFF
--- a/mdk/commands/behat.py
+++ b/mdk/commands/behat.py
@@ -192,7 +192,7 @@ class BehatCommand(Command):
             seleniumStorageUrl = 'https://selenium-release.storage.googleapis.com/'
             url = urllib.urlopen(seleniumStorageUrl)
             content = url.read()
-            matches = re.findall(r'[a-z0-9/._-]+selenium-server-standalone-[0-9.]+\.jar', content, re.I)
+            matches = sorted(re.findall(r'[a-z0-9/._-]+selenium-server-standalone-[0-9.]+\.jar', content, re.I))
             if len(matches) > 0:
                 seleniumUrl = seleniumStorageUrl + matches[-1]
                 logging.info('Downloading Selenium from %s' % seleniumUrl)

--- a/mdk/commands/behat.py
+++ b/mdk/commands/behat.py
@@ -189,17 +189,19 @@ class BehatCommand(Command):
             seleniumPath = args.selenium
         elif args.seleniumforcedl or (not nojavascript and not os.path.isfile(seleniumPath)):
             logging.info('Attempting to find a download for Selenium')
-            url = urllib.urlopen('http://docs.seleniumhq.org/download/')
+            seleniumStorageUrl = 'https://selenium-release.storage.googleapis.com/'
+            url = urllib.urlopen(seleniumStorageUrl)
             content = url.read()
-            selenium = re.search(r'http:[a-z0-9/._-]+selenium-server-standalone-[0-9.]+\.jar', content, re.I)
-            if selenium:
-                logging.info('Downloading Selenium from %s' % (selenium.group(0)))
+            matches = re.findall(r'[a-z0-9/._-]+selenium-server-standalone-[0-9.]+\.jar', content, re.I)
+            if len(matches) > 0:
+                seleniumUrl = seleniumStorageUrl + matches[-1]
+                logging.info('Downloading Selenium from %s' % seleniumUrl)
                 if (logging.getLogger().level <= logging.INFO):
-                    urllib.urlretrieve(selenium.group(0), seleniumPath, downloadProcessHook)
+                    urllib.urlretrieve(seleniumUrl, seleniumPath, downloadProcessHook)
                     # Force a new line after the hook display
                     logging.info('')
                 else:
-                    urllib.urlretrieve(selenium.group(0), seleniumPath)
+                    urllib.urlretrieve(seleniumUrl, seleniumPath)
             else:
                 logging.warning('Could not locate Selenium server to download')
 


### PR DESCRIPTION
This approach uses almost the same regex as before for detecting the Selenium Server JAR url - the main difference is that instead of scraping a user-facing website, we're scraping XML from Google APIs.

In this case, we're finding every Selenium Server standalone JAR, sorting the list and getting the last one in order to build a JAR url.