### PR TITLE
Add debugging, stop hang in ProcessInThread.

### DIFF
--- a/mdk/commands/behat.py
+++ b/mdk/commands/behat.py
@@ -322,9 +322,13 @@ class BehatCommand(Command):
 
                 # Kill the remaining processes
                 if phpServer and phpServer.is_alive():
+                    logging.debug('Killing phpServer...')
                     phpServer.kill()
+                    logging.debug('phpServer killed.')
                 if seleniumServer and seleniumServer.is_alive():
+                    logging.debug('Killing seleniumServer...')
                     seleniumServer.kill()
+                    logging.debug('seleniumServer killed.')
 
                 # Disable Behat
                 if args.disable:


### PR DESCRIPTION
Had a few problems getting things going with mdk - this fixes them.

Added a little debugging (which should only show when debug is configured anyway) to make it clearer what's going on.

2 problems fixed:

1) if something is already listening on the port selenium wants to use, selenium dies immediately. This caused an exception when trying to kill a nonexistent process.

2) hung in "while True" loop. Which is unnecessary & inefficient anyway. proc.poll() check was incorrect (should have checked for "is not None"), but using communicate() is simpler, easier to read, more efficient etc. anyway.
