### PR TITLE
MDLSITE-4668 integration.moodle.org has moved to https

### DIFF
--- a/mdk/config-dist.json
+++ b/mdk/config-dist.json
@@ -82,7 +82,7 @@
 
     // CI Server related settings
     "ci": {
-        "url": "http://integration.moodle.org",
+        "url": "https://integration.moodle.org",
         "token": null
     },
 


### PR DESCRIPTION
We are going to disable http requests at some point soon, this will break mdk ci