### PR TITLE
Behat path has been modified since Moodle 3.2.2 MDL_54628

### DIFF
--- a/mdk/commands/behat.py
+++ b/mdk/commands/behat.py
@@ -246,7 +246,12 @@ class BehatCommand(Command):
                     cmd.append('--format="progress" --out="{0}/progress.txt"'.format(outputDir))
                     cmd.append('--format="pretty" --out="{0}/pretty.txt"'.format(outputDir))
 
-            cmd.append('--config=%s/behat/behat.yml' % (M.get('behat_dataroot')))
+            # Since Moodle 32.2 behat directory is kept under $CFG->behat_dataroot for single and
+            # parallel runs.
+            if M.branch_compare(32):
+                cmd.append('--config=%s/behatrun/behat/behat.yml' % (M.get('behat_dataroot')))
+            else:
+                cmd.append('--config=%s/behat/behat.yml' % (M.get('behat_dataroot')))
 
             # Checking feature argument
             if args.feature:


### PR DESCRIPTION
All behat directories will be created within
$CFG->behat_dataroot, so parallel and single
runs can be handled and it doesn't pollute
user host system