### PR TITLE
New script to set up a clone for testing against the security repo.

### DIFF
--- a/mdk/config-dist.json
+++ b/mdk/config-dist.json
@@ -28,7 +28,8 @@
     "remotes": {
         "stable": "git://git.moodle.org/moodle.git",
         "integration": "git://git.moodle.org/integration.git",
-        "mine": "git@github.com:YourGitHub/moodle.git"
+        "mine": "git@github.com:YourGitHub/moodle.git",
+        "security": "git@git.in.moodle.com:integration/security.git"
     },
 
     // Database access

--- a/mdk/scripts/setupsecurity.sh
+++ b/mdk/scripts/setupsecurity.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+#
+# Script to setup a clone for testing against the security repository
+#
+# It removes existing origin remote and adds the security repository in
+# read-only mode. It also adds a git hook to prevent pushes. The purpose is to
+# prevent as much as possible that security issues are released to public
+# repositories.
+
+set -e
+
+GIT=`mdk config show git`
+REPOURL=`mdk config show remotes.security`
+ORIGINREMOTE=`mdk config show upstreamRemote`
+
+# Remove origin remote.
+echo "Deleting current origin remote..."
+$GIT remote rm $ORIGINREMOTE
+
+echo "Adding security repository remote as origin..."
+${GIT} remote add $ORIGINREMOTE $REPOURL
+
+# Pushes to an unexisting URL.
+${GIT} remote set-url --push $ORIGINREMOTE no-pushes-allowed
+
+
+# Git hook to prevent all pushes in case people is adding other remotes anyway.
+content="#!/bin/sh
+
+echo \"Sorry, pushes are not allowed. This clone is not supposed to be used
+to push stuff as you may accidentally push security patches to public repos\"
+exit 1"
+
+hookfile=".git/hooks/pre-push"
+
+if [ -f "$hookfile" ]; then
+    existingcontent=$(cat $hookfile)
+
+    if [[ "$content" != "$existingcontent" ]]; then
+        # Error if there is a hook we don't know about.
+        echo "Error: Security repository setup adds a pre-push hook to "\
+        "prevent accidental pushes to public repositories. You already have a "\
+        "pre-push hook, please delete it or back it up and merge it once "\
+        "security repository setup concluded."
+        exit 1
+    fi
+else
+    # Create the file.
+    echo "Adding a git hook to prevent pushes from this clone..."
+    cat > $hookfile << EOL
+$content
+EOL
+fi
+
+exit 0


### PR DESCRIPTION
Hi Fred,

I am not sure if you have access, but we discussed this proposal in https://tracker.moodle.org/browse/HQ-1429.

To resume a bit the PR; in a near future we will need minor release weeks' testing against the security repository instead of against integration.git. One of the advantages that we seek moving security issues to a security repository is to prevent security patches to be released to the public days before a minor release. Even if testing happens against security.git it is likely that at some point we (devs) make mistakes and push security patches to github; one of possible scenarios is that I am the assignee of an issue that is failing and I need to patch it. We should prevent devs pushing those branches to github and instead upload patch files to tracker.