### PR TITLE
Switch to using wide utf8 byte characters in MySQL install

### DIFF
--- a/mdk/db.py
+++ b/mdk/db.py
@@ -99,7 +99,13 @@ class DB(object):
             pass
 
         if self.engine in ('mysqli', 'mariadb'):
-            sql = 'CREATE DATABASE `%s` DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci' % db
+
+            if 'charset' in self.options and self.options['charset'] == 'utf8mb4':
+                placeholders = (db, 'utf8mb4', 'utf8mb4_unicode_ci')
+            else:
+                placeholders = (db, 'utf8', 'utf8_unicode_ci')
+
+            sql = 'CREATE DATABASE `%s` CHARACTER SET %s COLLATE %s' % placeholders
         elif self.engine == 'pgsql':
             sql = 'CREATE DATABASE "%s" WITH ENCODING \'UNICODE\'' % db
 

--- a/mdk/moodle.py
+++ b/mdk/moodle.py
@@ -391,8 +391,12 @@ class Moodle(object):
             fullname = self.identifier.replace('-', ' ').replace('_', ' ').title()
             fullname = fullname + ' ' + C.get('wording.%s' % engine)
 
+        dboptions =  C.get('db.%s' % engine)
+        if engine in ('mysqli', 'mariadb') and self.branch_compare(31):
+            dboptions['charset'] = 'utf8mb4'
+
         logging.info('Creating database...')
-        db = DB(engine, C.get('db.%s' % engine))
+        db = DB(engine, dboptions)
         if db.dbexists(dbname):
             if dropDb:
                 db.dropdb(dbname)


### PR DESCRIPTION
Knowing that you like to keep mdk backwards compatible with earlier Moodle versions, it was fun (tricky) to find a clean way to pass through the branch information to DB. I chose 31 as the branch to do this from, but I can understand why you would choose 33 instead.

Fixes #152