### PR TITLE
Warn the user if the keyring module can't be loaded

### DIFF
--- a/mdk/jira.py
+++ b/mdk/jira.py
@@ -35,10 +35,8 @@ import mimetypes
 try:
     import keyring
 except:
-    # TODO Find a better way of suggesting this
-    # debug('Could not load module keyring. You might want to install it.')
-    # debug('Try `apt-get install python-keyring`, or visit http://pypi.python.org/pypi/keyring')
-    pass
+    logging.warning('Could not load module keyring. You might want to install it.')
+    logging.warning('Try `apt-get install python-keyring`, or visit https://pypi.python.org/pypi/keyring#installation-instructions')
 
 C = Conf()
 


### PR DESCRIPTION
From time to time I am running into troubles with my local keyring installation. I am not sure what was the original intention but I think it is valid to warn the user if the keyring module can't be loaded - especially given it is enlisted among requirements.