### PR TITLE
Missing assignment for the sqlsrv cursor

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+v1.7.1
+- Fix missing assignment of the sqlsrv cursor - Jun Pataleta
+
 v1.7.0
 ------
 

--- a/mdk/db.py
+++ b/mdk/db.py
@@ -79,6 +79,7 @@ class DB(object):
                             % (host, port, user, password)
             self.conn = pyodbc.connect(connectionstr)
             self.conn.autocommit = True
+            self.cur = self.conn.cursor()
 
         else:
             raise Exception('DB engine %s not supported' % engine)

--- a/mdk/version.py
+++ b/mdk/version.py
@@ -22,4 +22,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 http://github.com/FMCorz/mdk
 """
 
-__version__ = "1.7.0"
+__version__ = "1.7.1"


### PR DESCRIPTION
When I tried to create an instance running on sqlsrv, I got the following:
> AttributeError: 'NoneType' object has no attribute 'execute'

This is because I accidentally nuked the assignment of sqlsrv's cursor to self.cur in my previous patch.

Created a patch for this, with a version bump commit as well. Hope this is okay. Thanks!