### PR TITLE
Make mdk precheck work again

### DIFF
--- a/mdk/ci.py
+++ b/mdk/ci.py
@@ -79,10 +79,9 @@ class CI(object):
         job = self.jenkins.get_job('Precheck remote branch')
 
         try:
-            invoke = job.invoke(build_params=params, securitytoken=self.token, invoke_pre_check_delay=0)
-            invoke.block_until_not_queued(60, 2)
+            invoke = job.invoke(build_params=params, securitytoken=self.token, delay=5, block=True)
         except TimeOut:
-            raise CIException('The build has been in queue for more than 60s. Aborting, please refer to: %s' % job.baseurl)
+            raise CIException('The build has been in queue for too long. Aborting, please refer to: %s' % job.baseurl)
         except JenkinsAPIException:
             raise CIException('Failed to invoke the build, check your permissions.')
 

--- a/mdk/ci.py
+++ b/mdk/ci.py
@@ -25,6 +25,7 @@ http://github.com/FMCorz/mdk
 import logging
 from jenkinsapi import jenkins
 from jenkinsapi.custom_exceptions import JenkinsAPIException, TimeOut
+from jenkinsapi.utils.crumb_requester import CrumbRequester
 from .config import Conf
 
 C = Conf()
@@ -63,7 +64,7 @@ class CI(object):
         logger.setLevel(logging.WARNING)
 
         # Loads the jenkins object.
-        self._jenkins = jenkins.Jenkins(self.url)
+        self._jenkins = jenkins.Jenkins(self.url, requester=CrumbRequester(baseurl=self.url))
 
     def precheckRemoteBranch(self, remote, branch, integrateto, issue=None):
         """Runs the precheck job and returns the outcome"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 keyring>=3.5
-jenkinsapi==0.2.25
+jenkinsapi>=0.3.2
 MySQL-python>=1.2.3
 psycopg2>=2.4.5
 requests>=2.3.0


### PR DESCRIPTION
After a recent upgrade of HQ CI Jenkins, the mdk precheck stopped working.