### PR TITLE
Automatically build distributed phpunit.xml files for each component

### DIFF
--- a/mdk/config-dist.json
+++ b/mdk/config-dist.json
@@ -193,6 +193,12 @@
         "launchSleep": 5
     },
 
+    // PHPUnit related settings
+    "phpunit": {
+        // Automatically build distributed phpunit.xml files for each component.
+        "buildcomponentconfigs": true
+    },
+
     // The name of the data directory (in dirs.storage/instanceName/)
     "dataDir": "moodledata",
     // The name of the www directory (in dirs.storage/instanceName/)

--- a/mdk/phpunit.py
+++ b/mdk/phpunit.py
@@ -24,6 +24,7 @@ http://github.com/FMCorz/mdk
 
 import logging
 import os
+from distutils.util import strtobool
 from .config import Conf
 from .tools import mkdir, process
 
@@ -115,6 +116,17 @@ class PHPUnit(object):
                 raise Exception('Something wrong with PHPUnit configuration')
             else:
                 raise exception
+
+        if strtobool(C.get('phpunit.buildcomponentconfigs')):
+            try:
+                result = self.M.cli('/admin/tool/phpunit/cli/util.php', args='--buildcomponentconfigs', stdout=None, stderr=None)
+            except Exception as exception:
+                pass
+
+            if exception != None or result[0] > 0:
+                raise Exception('Unable to build distributed phpunit.xml files for each component')
+            else:
+                logging.info('Distributed phpunit.xml files built.')
 
         logging.info('PHPUnit ready!')
 


### PR DESCRIPTION
I often make use of the buildcomponentconfigs feature allowing me to run all unit tests for the given component, such as

    vendor/bin/phpunit -c mod/workshop/

To be able to do so, I have to manually run `admin/tool/phpunit/cli/util.php --buildcomponentconfigs` every time. It makes sense to let mdk do it automatically.

Adding this feature was already discussed with @FMCorz at https://moodle.org/local/chatlogs/index.php?conversationid=19150#c605808 who has alternate way to achieve the same. However, I fail to remember that one. Also, there are cases when I simply run the phpunit manually without mdk.

So I still think it is worth considering to add this as an option, enabled by default as it does not hurt.

Further references: https://moodle.org/local/chatlogs/index.php?q=buildcomponentconfigs