### PR TITLE
Detect which SQL Server Driver is installed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,20 @@
 Changelog
 =========
 
+v1.7.2
+------
+
+- Update config for Moodle 3.5 - Jun Pataleta
+- Detect which SQL Server Driver is installed - Jun Pataleta
+- Improve type handling of values set using the config command
+- Support for setting URL of specific branches in config
+- Tidy up the version script - Andrew Nicols
+- Automatically build distributed phpunit.xml files for each component - David Mudrák
+- Make mdk precheck work again - David Mudrák
+
 v1.7.1
+------
+
 - Fix missing assignment of the sqlsrv cursor - Jun Pataleta
 
 v1.7.0

--- a/mdk/config-dist.json
+++ b/mdk/config-dist.json
@@ -128,6 +128,10 @@
                 "branch" : "Pull 3.4 Branch",
                 "diffurl" : "Pull 3.4 Diff URL"
             },
+            "35" : {
+                "branch" : "Pull 3.5 Branch",
+                "diffurl" : "Pull 3.5 Diff URL"
+            },
             "master" : {
                 "branch" : "Pull Master Branch",
                 "diffurl" : "Pull Master Diff URL"
@@ -253,7 +257,7 @@
     "useCacheAsUpstreamRemote": true,
 
     // You should not edit this, this is the branch that is considered as master by developers.
-    "masterBranch": 35,
+    "masterBranch": 36,
 
     // Aliases for MDK commands.
     // An alias starting with a ! will be executed through the command line. Those also

--- a/mdk/db.py
+++ b/mdk/db.py
@@ -75,8 +75,18 @@ class DB(object):
             port = int(options['port'])
             user = str(options['user'])
             password = str(options['passwd'])
-            connectionstr = "DRIVER={ODBC Driver 13 for SQL Server};SERVER=%s;PORT=%d;UID=%s;PWD=%s" \
-                            % (host, port, user, password)
+
+            # Look for installed ODBC Driver for SQL Server.
+            drivers = pyodbc.drivers()
+            sqlsrvdriver = next((driver for driver in drivers if "for SQL Server" in driver), None)
+            if sqlsrvdriver is None:
+                installurl = 'https://sqlchoice.azurewebsites.net/en-us/sql-server/developer-get-started/python'
+                raise Exception("You need to install an ODBC Driver for SQL Server. Check out %s for more info." % installurl)
+
+            logging.debug('Using %s' % sqlsrvdriver)
+
+            connectionstr = "DRIVER=%s;SERVER=%s;PORT=%d;UID=%s;PWD=%s" \
+                            % (sqlsrvdriver, host, port, user, password)
             self.conn = pyodbc.connect(connectionstr)
             self.conn.autocommit = True
             self.cur = self.conn.cursor()

--- a/mdk/version.py
+++ b/mdk/version.py
@@ -22,4 +22,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 http://github.com/FMCorz/mdk
 """
 
-__version__ = "1.7.1"
+__version__ = "1.7.2"


### PR DESCRIPTION
The driver for the sqlsrv connection string is currently hardcoded to 'ODBC Driver 13 for SQL Server'. This might not always be the case (e.g. updated mssql-tools in Ubuntu 16.04 now use 'ODBC Driver 17 for SQL Server').
So it's more proper to detect whether the installed ODBC driver and use the installed driver's name. If it's not installed, throw an exception and point devs to the docs URL to help them get started if they're not familiar about setting up ODBC drivers for SQL Server.