### PR TITLE
Invalidate config caches prior reading plugin versions

### DIFF
--- a/mdk/scripts/version.php
+++ b/mdk/scripts/version.php
@@ -10,6 +10,11 @@ cli_heading('Resetting all version numbers');
 
 $manager = core_plugin_manager::instance();
 
+// Purge caches to make sure we have the fresh information about versions.
+$manager::reset_caches();
+$configcache = cache::make('core', 'config');
+$configcache->purge();
+
 $plugininfo = $manager->get_plugins();
 foreach ($plugininfo as $type => $plugins) {
     foreach ($plugins as $name => $plugin) {
@@ -30,9 +35,6 @@ if ((float) $CFG->version !== $version) {
     mtrace("Updated main version from {$CFG->version} to {$version}");
 }
 
-// Purge all caches.
-$cache = cache::make('core', 'plugin_manager');
-$cache->purge();
-
-$cache = cache::make('core', 'config');
-$cache->purge();
+// Purge relevant caches again.
+$manager::reset_caches();
+$configcache->purge();


### PR DESCRIPTION
I usually had to purge caches manually after switching branch to make
mdk's version.php aware of the version number mismatch. Resetting the
config cache at the beginning of the script should help to avoid this.
The patch also makes use of the plugin manager's API to reset its
own caches.