### PR TITLE
Do not use an extra dot in the mdkscriptrun script

### DIFF
--- a/mdk/scripts.py
+++ b/mdk/scripts.py
@@ -138,7 +138,7 @@ class Scripts(object):
 
         i = 0
         while True:
-            candidate = os.path.join(path, 'mdkscriptrun{}.{}'.format(i if i > 0 else '', ext))
+            candidate = os.path.join(path, 'mdkscriptrun{}{}'.format(i if i > 0 else '', ext))
             if not os.path.isfile(candidate):
                 break
             i += 1


### PR DESCRIPTION
The `os.path.splitext()` already returns the extension with the leading
dot. So it was creating files like `mdkscriptrun..sh` with the extra dot
in the name. The patch removes the extra dot.