### PR TITLE
Add ability to define custom $CFG->prefix for new instances

### DIFF
--- a/mdk/config-dist.json
+++ b/mdk/config-dist.json
@@ -36,6 +36,8 @@
     "db": {
         // Name prefix for all databases created by mdk. Affects the database name only, not the tables.
         "namePrefix": "",
+        // Tables name prefix to be set in the config.php during the instance creation.
+        "tablePrefix": "mdl_",
         "mariadb": {
             "host": "localhost",
             "port": "3306",

--- a/mdk/moodle.py
+++ b/mdk/moodle.py
@@ -410,8 +410,8 @@ class Moodle(object):
 
         logging.info('Installing %s...' % self.identifier)
         cli = 'admin/cli/install.php'
-        params = (wwwroot, dataDir, engine, dbname, C.get('db.%s.user' % engine), C.get('db.%s.passwd' % engine), C.get('db.%s.host' % engine), C.get('db.%s.port' % engine), fullname, self.identifier, C.get('login'), C.get('passwd'))
-        args = '--wwwroot="%s" --dataroot="%s" --dbtype="%s" --dbname="%s" --dbuser="%s" --dbpass="%s" --dbhost="%s" --dbport="%s" --fullname="%s" --shortname="%s" --adminuser="%s" --adminpass="%s" --allow-unstable --agree-license --non-interactive' % params
+        params = (wwwroot, dataDir, engine, dbname, C.get('db.%s.user' % engine), C.get('db.%s.passwd' % engine), C.get('db.%s.host' % engine), C.get('db.%s.port' % engine), C.get('db.tablePrefix'), fullname, self.identifier, C.get('login'), C.get('passwd'))
+        args = '--wwwroot="%s" --dataroot="%s" --dbtype="%s" --dbname="%s" --dbuser="%s" --dbpass="%s" --dbhost="%s" --dbport="%s" --prefix="%s" --fullname="%s" --shortname="%s" --adminuser="%s" --adminpass="%s" --allow-unstable --agree-license --non-interactive' % params
         result = self.cli(cli, args, stdout=None, stderr=None)
         if result[0] != 0:
             raise InstallException('Error while running the install, please manually fix the problem.\n- Command was: %s %s %s' % (C.get('php'), cli, args))


### PR DESCRIPTION
When reviewing contributed plugins and patches, it sometimes happens that the developer puts hard-coded table name into their SQL queries by mistake, such as
```
$sql = "SELECT id, foo, bar FROM mdl_foo_bar";
```
instead of the correct one
```
$sql = "SELECT id, foo, bar FROM {foo_bar}";
```

As most of the sites are using the default `mdl_` table name prefix, this kind of bugs may be hard to be spotted. It will help if the reviewer/tester has a custom non-default table name prefix set while testing the plugins and patches. Thanks in advance for considering it.