### PR TITLE
Add support for repeating tests

### DIFF
--- a/mdk/commands/phpunit.py
+++ b/mdk/commands/phpunit.py
@@ -104,6 +104,15 @@ class PhpunitCommand(Command):
             }
         ),
         (
+            ['--repeat'],
+            {
+                'default': None,
+                'help': 'run tests repeatedly for the given number of times',
+                'metavar': 'times',
+                'type': int
+            }
+        ),
+        (
             ['name'],
             {
                 'default': None,
@@ -142,13 +151,21 @@ class PhpunitCommand(Command):
         if testsuite and not testsuite.endswith('_testsuite'):
             testsuite += '_testsuite'
 
+        # Check repeat arg.
+        repeat = args.repeat
+        if repeat:
+            # Make sure repeat is greater than 1.
+            if repeat <= 1:
+                repeat = None
+
         kwargs = {
             'coverage': args.coverage,
             'filter': args.filter,
             'testcase': args.testcase,
             'testsuite': testsuite,
             'unittest': args.unittest,
-            'stopon': [] if not args.stoponfailure else ['failure']
+            'stopon': [] if not args.stoponfailure else ['failure'],
+            'repeat': repeat
         }
 
         if args.run:

--- a/mdk/phpunit.py
+++ b/mdk/phpunit.py
@@ -40,7 +40,7 @@ class PHPUnit(object):
         self._Wp = Wp
         self._M = M
 
-    def getCommand(self, testcase=None, unittest=None, filter=None, coverage=None, testsuite=None, stopon=None):
+    def getCommand(self, testcase=None, unittest=None, filter=None, coverage=None, testsuite=None, stopon=None, repeat=None):
         """Get the PHPUnit command"""
         cmd = []
         if self.usesComposer():
@@ -55,6 +55,9 @@ class PHPUnit(object):
         if stopon:
             for on in stopon:
                 cmd.append('--stop-on-%s' % on)
+
+        if repeat:
+            cmd.append('--repeat=%d' % repeat)
 
         if testcase:
             cmd.append(testcase)


### PR DESCRIPTION
It would be great to add support for PHPUnit's --repeat argument in
order to run tests repeatedly which is useful for testing random
PHPUnit errors.