### PR TITLE
Set cachetemplates config value for dev/undev scripts

### DIFF
--- a/mdk/scripts/dev.php
+++ b/mdk/scripts/dev.php
@@ -60,6 +60,9 @@ mdk_set_config('requiremodintro', 0, 'page');
 mdk_set_config('requiremodintro', 0, 'resource');
 mdk_set_config('requiremodintro', 0, 'url');
 
+// Don't cache templates.
+mdk_set_config('cachetemplates', 0);
+
 // Adds FirePHP
 $firephp = "
 // FirePHP

--- a/mdk/scripts/mindev.php
+++ b/mdk/scripts/mindev.php
@@ -84,3 +84,5 @@ mdk_set_config('langstringcache', 1);
 // Use YUI combo loading.
 mdk_set_config('yuicomboloading', 1);
 
+// Don't cache templates.
+mdk_set_config('cachetemplates', 0);

--- a/mdk/scripts/undev.php
+++ b/mdk/scripts/undev.php
@@ -106,3 +106,6 @@ foreach ($resources as $r) {
         mdk_set_config('requiremodintro', $default, $r);
     }
 }
+
+// Cache templates.
+mdk_set_config('cachetemplates', 1);


### PR DESCRIPTION
It's a new setting for 3.8 which enables the caching of templates in
order to improve page loading performance for production sites. Although
on dev, this setting should be disabled.