### PR TITLE
Improve version.php script (do not prompt for upgrade after running it)

### DIFF
--- a/mdk/scripts/version.php
+++ b/mdk/scripts/version.php
@@ -14,11 +14,14 @@ $manager = core_plugin_manager::instance();
 $manager::reset_caches();
 $configcache = cache::make('core', 'config');
 $configcache->purge();
+$needsupgrade = false;
+$wasdowngraded = false;
 
 $plugininfo = $manager->get_plugins();
 foreach ($plugininfo as $type => $plugins) {
     foreach ($plugins as $name => $plugin) {
         if ($plugin->get_status() !== core_plugin_manager::PLUGIN_STATUS_DOWNGRADE) {
+            $needsupgrade = $needsupgrade || $plugin->get_status() !== core_plugin_manager::PLUGIN_STATUS_UPTODATE;
             continue;
         }
 
@@ -26,13 +29,23 @@ foreach ($plugininfo as $type => $plugins) {
 
         mtrace("Updating {$frankenstyle} from {$plugin->versiondb} to {$plugin->versiondisk}");
         $DB->set_field('config_plugins', 'value', $plugin->versiondisk, array('name' => 'version', 'plugin' => $frankenstyle));
+        $wasdowngraded = true;
     }
 }
 
 // Check that the main version hasn't changed.
-if ((float) $CFG->version !== $version) {
+if ((float) $CFG->version > $version) {
     set_config('version', $version);
     mtrace("Updated main version from {$CFG->version} to {$version}");
+    $wasdowngraded = true;
+} else if ('' . $CFG->version !== '' . $version) {
+    $needsupgrade = true;
+}
+
+if ($wasdowngraded && !$needsupgrade) {
+    // Update version hash so Moodle doesn't think that we need to run upgrade.
+    $manager::reset_caches();
+    set_config('allversionshash', core_component::get_all_versions_hash());
 }
 
 // Purge relevant caches again.


### PR DESCRIPTION
- do not accidentally bump the core version up
- if we downgraded any plugins or core and moodle does not need upgrade, update the verison hash
This way we won't need to run upgrade script after fixing version