### PR TITLE
Allow forceCfg to also set a non-scalar value such as behat_profiles

### DIFF
--- a/mdk/config-dist.json
+++ b/mdk/config-dist.json
@@ -198,6 +198,25 @@
     "forceCfg": {
         // The following example will set CFG->divertallemailsto to "root@localhost.local".
         // "divertallemailsto": "root@localhost.local"
+
+        // In order to set a CFG variable as an array rather than scalar, Python lists or dictionaries can be used.
+        // "behat_profiles": {
+        //     "default": {
+        //         "browser": "chrome",
+        //         "extensions": {
+        //             "Behat\\\\MinkExtension": {
+        //                 "selenium2": {
+        //                     "browser": "chrome"
+        //                 }
+        //             }
+        //         }
+        //     }
+        // },
+        // "behat_parallel_run": [
+        //     {"wd_host": "http:\/\/127.0.0.1:4444\/wd\/hub"},
+        //     {"wd_host": "http:\/\/127.0.0.1:4445\/wd\/hub"},
+        //     {"wd_host": "http:\/\/127.0.0.1:4446\/wd\/hub"}
+        // ]
     },
 
     // Behat related settings

--- a/mdk/moodle.py
+++ b/mdk/moodle.py
@@ -27,6 +27,7 @@ import re
 import logging
 import shutil
 import subprocess
+import json
 from tempfile import gettempdir
 
 from .tools import getMDLFromCommitMessage, mkdir, process, parseBranch
@@ -86,6 +87,8 @@ class Moodle(object):
 
         if type(value) == bool:
             value = 'true' if value else 'false'
+        elif type(value) in (dict, list):
+            value = "json_decode('" + json.dumps(value) + "', true)"
         elif type(value) != int:
             value = "'" + str(value) + "'"
         value = str(value)


### PR DESCRIPTION
In order to make Behat running in my environment, I have to set the `behat_profiles` in my config.php. However, every time I re-install an MDK instance, I loose that setting and have to add it back to the new config.php. To avoid that, I would like to add the `behat_profiles` (and also `behat_parallel_run` which I also often define) into the `forceCfg`. However, at the moment, only strings and integer values are supported there.

This pull request adds support for non-scalar values - dictionaries (associative arrays) and lists (non-associative arrays) - in the `forceCfg`.