### PR TITLE
feature: open jira ticket in default browser

### DIFF
--- a/mdk/commands/tracker.py
+++ b/mdk/commands/tracker.py
@@ -34,6 +34,13 @@ class TrackerCommand(Command):
 
     _arguments = [
         (
+            ['--open'],
+            {
+                'action': 'store_true',
+                'help': 'Open issue in browser'
+            }
+        ),
+        (
             ['-t', '--testing'],
             {
                 'action': 'store_true',
@@ -95,8 +102,13 @@ class TrackerCommand(Command):
         if not issue or not re.match('(MDL|mdl)?(-|_)?[1-9]+', issue):
             raise Exception('Invalid or unknown issue number')
 
-        self.Jira = Jira()
         self.mdl = 'MDL-' + re.sub(r'(MDL|mdl)(-|_)?', '', issue)
+
+        if args.open:
+            Jira.openInBrowser(self.mdl)
+            return
+
+        self.Jira = Jira()
 
         if args.addlabels:
             if 'triaged' in args.addlabels:

--- a/mdk/jira.py
+++ b/mdk/jira.py
@@ -31,6 +31,7 @@ import re
 import logging
 import os
 import requests
+import webbrowser
 import mimetypes
 try:
     import keyring
@@ -398,6 +399,11 @@ class Jira(object):
 
         return True
 
+    @staticmethod
+    def openInBrowser(key):
+        jiraurl = C.get('tracker.url').rstrip('/')
+        url = "{0}/browse/{1}".format(jiraurl, key)
+        webbrowser.open_new_tab(url)
 
 class JiraException(Exception):
     pass


### PR DESCRIPTION
Add ability to open current jira issue in default web browser: `mdk tracker --open`