### PR TITLE
Specify Git path during initialization

### DIFF
--- a/mdk/commands/init.py
+++ b/mdk/commands/init.py
@@ -138,6 +138,20 @@ class InitCommand(Command):
             C.set('dirs.storage', storage)
             break
 
+        while True:
+            git = question('What is the path of your Git installation?', C.get('git'))
+            git = self.resolve_directory(git, username)
+
+            if not os.access(git, os.X_OK):
+                logging.error('Error while executing the Git command by path %s' % git + '.\nPlease fix or use another executable path.')
+                continue
+
+            gitversion = subprocess.run([git, '--version'], stdout=subprocess.PIPE)
+            logging.info('Using ' + gitversion.stdout.decode('utf-8'))
+
+            C.set('git', git)
+            break
+
         # The default configuration file should point to the right directory for dirs.mdk,
         # we will just ensure that it exists.
         mdkdir = C.get('dirs.mdk')


### PR DESCRIPTION
Hi @junpataleta and/or @FMCorz 

I've had troubles creating my first instance, because Git was set (initially) false for my environment. After I made some research on this toolkit and found out that this path is specified in the config file. For sure, for more than 90% of cases, it will work out of the box.

So I had the idea, why we don't ask that in the initialization as it's a requirement. What do you think about my proposed code/solution/idea?

Cheers
Adrian