### PR TITLE
Avoid PHP Notice "Undefined variable: DB" in PHPUnit setup

### DIFF
--- a/mdk/scripts/dev.php
+++ b/mdk/scripts/dev.php
@@ -68,7 +68,7 @@ mdk_set_config('cachetemplates', 0);
 
 // Adds moodle_database declaration to help VSCode detect moodle_database.
 $varmoodledb = '/** @var moodle_database */
-$DB = $DB;
+$DB = isset($DB) ? $DB : null;
 ';
 $conffile = dirname(__FILE__) . '/config.php';
 if ($content = file_get_contents($conffile)) {


### PR DESCRIPTION
Without declaring $DB as a global variable in config.php (similarly to
how it is done for $CFG), the PHPUnit raises

    Notice: Undefined variable: DB in {...}/config.php on line 44