### PR TITLE
fix plugin version for Moodle minor versions >9

### DIFF
--- a/mdk/plugins.py
+++ b/mdk/plugins.py
@@ -445,7 +445,10 @@ class PluginRepository(object):
             "branch": round(float(branch) / 10., 1),
             "plugin": plugin
         }
-
+        # If the branch is e. g. 311, we are now at 31.1 instead of 311
+        if data['branch'] > 10:
+            data['branch'] = round(float(branch) / 100., 2)
+        
         logging.info('Retrieving information for plugin %s and branch %s' % (data['plugin'], data['branch']))
         try:
             resp = self.request('pluginfo.php', 'GET', data)


### PR DESCRIPTION
Currently, the plugin version is calculated by dividing the Moodle version by 10. This is wrong for versions like 3.10 or 3.11:

```
$ mdk create --version 310 --install --engine mysqli --run dev
$ mdk plugin install qbehaviour_adaptivemultipart stable_310

Retrieving information for plugin qbehaviour_adaptivemultipart and branch 31.0
No result found
Retrieving information for plugin qbehaviour_adaptivemultipart and branch 30.9
No result found
Could not find a file for this plugin
```

With the fix, it works fine:

```
$ mdk plugin install qbehaviour_adaptivemultipart stable_310

Retrieving information for plugin qbehaviour_adaptivemultipart and branch 3.1
Found cached plugin file: qbehaviour_adaptivemultipart-310.zip
Extracting plugin...
Upgrading Moodle to install the new plugin
```

The fix is not perfect, but it will work until we get Moodle to a major version 10...