### PR TITLE
Remove --dev arg from composer install

### DIFF
--- a/mdk/commands/behat.py
+++ b/mdk/commands/behat.py
@@ -181,7 +181,7 @@ class BehatCommand(Command):
                 f.close()
             M.cli('/' + cliFile, stdout=None, stderr=None)
             os.remove(cliPath)
-            M.cli('composer.phar', args='install --dev', stdout=None, stderr=None)
+            M.cli('composer.phar', args='install', stdout=None, stderr=None)
 
         # Download selenium
         seleniumPath = os.path.expanduser(os.path.join(self.C.get('dirs.mdk'), 'selenium.jar'))

--- a/mdk/commands/phpunit.py
+++ b/mdk/commands/phpunit.py
@@ -194,7 +194,7 @@ class PhpunitCommand(Command):
                     f.close()
                 M.cli('/' + cliFile, stdout=None, stderr=None)
                 os.remove(cliPath)
-                M.cli('composer.phar', args='install --dev', stdout=None, stderr=None)
+                M.cli('composer.phar', args='install', stdout=None, stderr=None)
 
         # If Oracle, ask the user for a Behat prefix, if not set.
         prefix = M.get('phpunit_prefix')


### PR DESCRIPTION
This option was deprecated in Composer 2 and will be removed in Composer 3.