### PR TITLE
Replace references of `master` with `main`

### DIFF
--- a/mdk/commands/create.py
+++ b/mdk/commands/create.py
@@ -96,7 +96,7 @@ class CreateCommand(Command):
                 ['-v', '--version'],
                 {
                     'choices': version_options(),
-                    'default': ['master'],
+                    'default': ['main'],
                     'help': 'version of Moodle',
                     'metavar': 'version',
                     'nargs': '*'
@@ -149,7 +149,7 @@ class CreateCommand(Command):
 
         # Wording version
         versionNice = version
-        if version == 'master':
+        if version in ['master', 'main']:
             versionNice = self.C.get('wording.master')
 
         # Generating names

--- a/mdk/commands/plugin.py
+++ b/mdk/commands/plugin.py
@@ -222,7 +222,7 @@ class PluginCommand(Command):
             return False
 
         branch = M.get('branch')
-        if branch == 'master':
+        if branch in ['master', 'main']:
             branch = C.get('masterBranch')
         branch = int(branch)
 

--- a/mdk/commands/push.py
+++ b/mdk/commands/push.py
@@ -79,7 +79,7 @@ class PushCommand(Command):
                 {
                     'action': 'store_true',
                     'dest': 'includestable',
-                    'help': 'also push the stable branch (MOODLE_xx_STABLE, master)'
+                    'help': 'also push the stable branch (MOODLE_xx_STABLE, main)'
                 }
             ),
             (

--- a/mdk/config-dist.json
+++ b/mdk/config-dist.json
@@ -70,7 +70,8 @@
         // How to name your instances
         "prefixStable": "stable_",
         "prefixIntegration": "integration_",
-        "prefixMaster": "main",
+        "prefixMain": "main",
+        "prefixMaster": "master",
         "suffixSeparator": "_",
 
         // How to name your branches

--- a/mdk/config-dist.json
+++ b/mdk/config-dist.json
@@ -70,7 +70,7 @@
         // How to name your instances
         "prefixStable": "stable_",
         "prefixIntegration": "integration_",
-        "prefixMaster": "master",
+        "prefixMaster": "main",
         "suffixSeparator": "_",
 
         // How to name your branches
@@ -82,7 +82,7 @@
 
         // How to name your Moodle installation
         "integration": "Integration",
-        "master": "Master",
+        "master": "Main",
         "stable": "Stable",
         "mariadb": "MariaDB",
         "mysqli": "MySQL",
@@ -173,6 +173,11 @@
             "403" : {
                 "branch" : "Pull 4.3 Branch",
                 "diffurl" : "Pull 4.3 Diff URL"
+            },
+            // TODO: Update to Main once the fields have been renamed in the tracker.
+            "main" : {
+                "branch" : "Pull Master Branch",
+                "diffurl" : "Pull Master Diff URL"
             },
             "master" : {
                 "branch" : "Pull Master Branch",

--- a/mdk/jira.py
+++ b/mdk/jira.py
@@ -184,7 +184,7 @@ class Jira(object):
             if key == 'repositoryurl':
                 infos['repo'] = fields.get(value)
 
-            elif key == 'master' or key.isdigit():
+            elif key in ['master', 'main'] or key.isdigit():
                 infos['branches'][key] = {
                     'branch': fields.get(value['branch']),
                     'compare': fields.get(value['diffurl'])

--- a/mdk/moodle.py
+++ b/mdk/moodle.py
@@ -30,7 +30,7 @@ import subprocess
 import json
 from tempfile import gettempdir
 
-from .tools import getMDLFromCommitMessage, mkdir, process, parseBranch
+from .tools import getMDLFromCommitMessage, mkdir, process, parseBranch, stableBranch
 from .db import DB
 from .config import Conf
 from .git import Git, GitException
@@ -129,7 +129,7 @@ class Moodle(object):
         b = self.get('branch')
         if b == None:
             raise Exception('Error while reading the branch')
-        elif b == 'master':
+        elif b in ['master', 'main']:
             b = C.get('masterBranch')
         b = int(b)
         if compare == '>=':
@@ -518,13 +518,10 @@ class Moodle(object):
                 self.version['branch'] = self.version['release'].replace('.', '')[0:2]
                 branch = self.version['branch']
             if int(branch) >= int(C.get('masterBranch')):
-                self.version['branch'] = 'master'
+                self.version['branch'] = 'main'
 
             # Stable branch
-            if self.version['branch'] == 'master':
-                self.version['stablebranch'] = 'master'
-            else:
-                self.version['stablebranch'] = 'MOODLE_%s_STABLE' % self.version['branch']
+            self.version['stablebranch'] = stableBranch(self.version['branch'], self.git())
 
             # Integration or stable?
             self.version['integration'] = self.isIntegration()

--- a/mdk/tools.py
+++ b/mdk/tools.py
@@ -222,8 +222,7 @@ def stableBranch(version, git=None):
     if version in ['master', 'main']:
         if git is not None and not git.hasBranch('main'):
             # Fall back to master if main is not yet available.
-            logging.info('%s: The main branch is not yet available. Please run `mdk update`.\n'
-                         '  Falling back to master...' % __name__)
+            logging.info('The main branch has not been found, using master instead.')
             return 'master'
         return 'main'
     return 'MOODLE_%d_STABLE' % int(version)

--- a/mdk/tools.py
+++ b/mdk/tools.py
@@ -218,9 +218,14 @@ def natural_sort_key(s, _nsre=re.compile('([0-9]+)')):
     return [int(text) if text.isdigit() else text.lower() for text in _nsre.split(s)]
 
 
-def stableBranch(version):
-    if version == 'master':
-        return 'master'
+def stableBranch(version, git=None):
+    if version in ['master', 'main']:
+        if git is not None and not git.hasBranch('main'):
+            # Fall back to master if main is not yet available.
+            logging.info('%s: The main branch is not yet available. Please run `mdk update`.\n'
+                         '  Falling back to master...' % __name__)
+            return 'master'
+        return 'main'
     return 'MOODLE_%d_STABLE' % int(version)
 
 
@@ -228,7 +233,7 @@ def version_options():
     return ([str(x) for x in range(13, 40)]
             + [str(x) for x in range(310, 312)]
             + [str(x) for x in range(400, C.get('masterBranch'))]
-            + ['master'])
+            + ['master', 'main'])
 
 class ProcessInThread(threading.Thread):
     """Executes a process in a separate thread"""

--- a/mdk/workplace.py
+++ b/mdk/workplace.py
@@ -114,7 +114,7 @@ class Workplace(object):
                 logging.info('Have a break, this operation is slow...')
                 process('%s clone --mirror %s %s' % (C.get('git'), C.get('remotes.integration'), cacheIntegration))
 
-    def create(self, name=None, version='master', integration=False, useCacheAsRemote=False):
+    def create(self, name=None, version='main', integration=False, useCacheAsRemote=False):
         """Creates a new instance of Moodle.
         The parameter useCacheAsRemote has been deprecated.
         """
@@ -130,7 +130,7 @@ class Workplace(object):
         extraDir = self.getPath(name, 'extra')
         linkDir = os.path.join(self.www, name)
         extraLinkDir = os.path.join(self.getMdkWebDir(), name)
-        branch = stableBranch(version)
+        branch = stableBranch(version, git.Git(self.getCachedRemote(integration), C.get('git')))
 
         useCacheAsUpstream = C.get('useCacheAsUpstreamRemote')
         cloneAsShared = useCacheAsUpstream and C.get('useCacheAsSharedClone')
@@ -243,7 +243,7 @@ class Workplace(object):
             name = identifier.replace(' ', '_')
         else:
             # Wording version
-            if version == 'master':
+            if version in ['master', 'main']:
                 prefixVersion = C.get('wording.prefixMaster')
             else:
                 prefixVersion = version

--- a/mdk/workplace.py
+++ b/mdk/workplace.py
@@ -243,8 +243,10 @@ class Workplace(object):
             name = identifier.replace(' ', '_')
         else:
             # Wording version
-            if version in ['master', 'main']:
+            if version == 'master':
                 prefixVersion = C.get('wording.prefixMaster')
+            elif version == 'main':
+                prefixVersion = C.get('wording.prefixMain')
             else:
                 prefixVersion = version
 


### PR DESCRIPTION
Additional notes:
- `DoctorCommand.masterbranch` has been renamed to `DoctorCommand.mainbranch` but the `--masterbranch` argument is retained (for now).

See https://tracker.moodle.org/browse/MDLSITE-7418 for more information.