### PR TITLE
Add tool.version_options

### DIFF
--- a/mdk/commands/backport.py
+++ b/mdk/commands/backport.py
@@ -25,7 +25,7 @@ http://github.com/FMCorz/mdk
 import logging
 from .. import tools, css, jira
 from ..command import Command
-from ..tools import yesOrNo
+from ..tools import yesOrNo, version_options
 
 
 class BackportCommand(Command):
@@ -93,7 +93,7 @@ class BackportCommand(Command):
             (
                 ['-v', '--versions'],
                 {
-                    'choices': [str(x) for x in range(13, int(self.C.get('masterBranch')))] + ['master'],
+                    'choices': version_options(),
                     'help': 'versions to backport to',
                     'metavar': 'version',
                     'nargs': '+',

--- a/mdk/commands/create.py
+++ b/mdk/commands/create.py
@@ -27,7 +27,7 @@ import logging
 
 from ..db import DB
 from ..command import Command
-from ..tools import yesOrNo
+from ..tools import yesOrNo, version_options
 from ..exceptions import CreateException, InstallException
 
 
@@ -95,7 +95,7 @@ class CreateCommand(Command):
             (
                 ['-v', '--version'],
                 {
-                    'choices': [str(x) for x in range(13, int(self.C.get('masterBranch')))] + ['master'],
+                    'choices': version_options(),
                     'default': ['master'],
                     'help': 'version of Moodle',
                     'metavar': 'version',

--- a/mdk/commands/rebase.py
+++ b/mdk/commands/rebase.py
@@ -24,7 +24,7 @@ http://github.com/FMCorz/mdk
 
 import logging
 from ..command import Command
-
+from ..tools import version_options
 
 class RebaseCommand(Command):
 
@@ -52,7 +52,7 @@ class RebaseCommand(Command):
             (
                 ['-v', '--versions'],
                 {
-                    'choices': [str(x) for x in range(13, int(self.C.get('masterBranch')))] + ['master'],
+                    'choices': version_options(),
                     'help': 'versions to rebase the issues on. Ignored if names is set.',
                     'metavar': 'version',
                     'nargs': '+'

--- a/mdk/tools.py
+++ b/mdk/tools.py
@@ -224,6 +224,12 @@ def stableBranch(version):
     return 'MOODLE_%d_STABLE' % int(version)
 
 
+def version_options():
+    return ([str(x) for x in range(13, 40)]
+            + [str(x) for x in range(310, 312)]
+            + [str(x) for x in range(400, C.get('masterBranch'))]
+            + ['master'])
+
 class ProcessInThread(threading.Thread):
     """Executes a process in a separate thread"""
 


### PR DESCRIPTION
With the version format changes starting 3.10, the version options have included non-existent versions. This adds a utility function for generating the version options that match the actual released versions of Moodle.