### PR TITLE
Update theme settings location for 4.4 and up.

### DIFF
--- a/mdk/scripts/undev.php
+++ b/mdk/scripts/undev.php
@@ -63,7 +63,12 @@ mdk_set_config('cronclionly', $default);
 
 
 // Theme settings.
-$settingspage = $adminroot->locate('themesettings', true);
+// `themesettings` has been changed to `themesettingsadvanced` since 4.4.
+$settingspage = $adminroot->locate('themesettingsadvanced', true);
+if (empty($settingspage)) {
+    // Fall back to `themesettings` for Moodle 4.3 and below.
+    $settingspage = $adminroot->locate('themesettings', true);
+}
 $settings = $settingspage->settings;
 
 // Allow themes to be changed from the URL.


### PR DESCRIPTION
From 4.4, the settings in the `themesettings` section have been moved to `themesettingsadvanced`.

This patch adds the fetching of the theme settings from the new `themesettingsadvanced` section to support 4.4 and up but falls back to `themesettings` to support 4.3 and below.

See https://tracker.moodle.org/browse/MDL-78426.