### PR TITLE
Clean up Pull X.Y fields belonging to legacy branches 

### DIFF
--- a/mdk/config-dist.json
+++ b/mdk/config-dist.json
@@ -106,66 +106,6 @@
         "username": false,
         "fieldnames" : {
             "repositoryurl" : "Pull  from Repository",
-            "27" : {
-                "branch" : "Pull 2.7 Branch",
-                "diffurl" : "Pull 2.7 Diff URL"
-            },
-            "29" : {
-                "branch" : "Pull 2.9 Branch",
-                "diffurl" : "Pull 2.9 Diff URL"
-            },
-            "30" : {
-                "branch" : "Pull 3.0 Branch",
-                "diffurl" : "Pull 3.0 Diff URL"
-            },
-            "31" : {
-                "branch" : "Pull 3.1 Branch",
-                "diffurl" : "Pull 3.1 Diff URL"
-            },
-            "32" : {
-                "branch" : "Pull 3.2 Branch",
-                "diffurl" : "Pull 3.2 Diff URL"
-            },
-            "33" : {
-                "branch" : "Pull 3.3 Branch",
-                "diffurl" : "Pull 3.3 Diff URL"
-            },
-            "34" : {
-                "branch" : "Pull 3.4 Branch",
-                "diffurl" : "Pull 3.4 Diff URL"
-            },
-            "35" : {
-                "branch" : "Pull 3.5 Branch",
-                "diffurl" : "Pull 3.5 Diff URL"
-            },
-            "36" : {
-                "branch" : "Pull 3.6 Branch",
-                "diffurl" : "Pull 3.6 Diff URL"
-            },
-            "37" : {
-                "branch" : "Pull 3.7 Branch",
-                "diffurl" : "Pull 3.7 Diff URL"
-            },
-            "38" : {
-                "branch" : "Pull 3.8 Branch",
-                "diffurl" : "Pull 3.8 Diff URL"
-            },
-            "39" : {
-                "branch" : "Pull 3.9 Branch",
-                "diffurl" : "Pull 3.9 Diff URL"
-            },
-            "310" : {
-                "branch" : "Pull 3.10 Branch",
-                "diffurl" : "Pull 3.10 Diff URL"
-            },
-            "311" : {
-                "branch" : "Pull 3.11 Branch",
-                "diffurl" : "Pull 3.11 Diff URL"
-            },
-            "400" : {
-                "branch" : "Pull 4.0 Branch",
-                "diffurl" : "Pull 4.0 Diff URL"
-            },
             "401" : {
                 "branch" : "Pull 4.1 Branch",
                 "diffurl" : "Pull 4.1 Diff URL"

--- a/mdk/moodle.py
+++ b/mdk/moodle.py
@@ -788,9 +788,16 @@ class Moodle(object):
         fieldrepositoryurl = C.get('tracker.fieldnames.repositoryurl')
         fieldbranch = C.get('tracker.fieldnames.%s.branch' % version)
         fielddiffurl = C.get('tracker.fieldnames.%s.diffurl' % version)
+        masterbranch = C.get('masterBranch')
 
         if not fieldrepositoryurl or not fieldbranch or not fielddiffurl:
-            logging.error('Cannot set tracker fields for this version (%s). The field names are not set in the config file.', version)
+            errormsg = 'Cannot set tracker fields for this version (%s).' % version
+            if version == masterbranch or version == masterbranch - 1:
+                # MDK might not have been updated with the latest release so the field names are not yet present.
+                errormsg += ' The field names are not set in the config file.'
+            else:
+                errormsg += ' Tracker fields belonging to legacy Moodle versions are removed from the tracker.'
+            logging.error(errormsg)
         else:
             logging.info('Setting tracker fields: \n  %s: %s \n  %s: %s \n  %s: %s' %
                 (fieldrepositoryurl, repositoryurl, fieldbranch, branch, fielddiffurl, diffurl))


### PR DESCRIPTION
Custom fields belonging to legacy branches are being removed from the tracker as part of the Moodle release process. 

As of the 4.4 release, `Pull X.Y` custom fields belonging to versions 4.0 and lower are no longer in the tracker. So, we might as well clean up the `config-dist.json` of the custom fields belonging to these legacy branches.