### PR TITLE
Python 3.11 and 3.12 compatibility changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ psycopg2>=2.4.5
 requests>=2.3.0
 watchdog>=0.8.0
 pyodbc>=4.0.21
+setuptools>=60.2.0


### PR DESCRIPTION
For Python 3.11 and later,
We need `setuptools` package, other the `mdk create` command cannot be executed