### PR TITLE
Remove `master` branch support

### DIFF
--- a/mdk/commands/create.py
+++ b/mdk/commands/create.py
@@ -159,7 +159,7 @@ class CreateCommand(Command):
 
         # Wording version
         versionNice = version
-        if version in ['master', 'main']:
+        if version in ['main']:
             versionNice = self.C.get('wording.master')
 
         # Generating names

--- a/mdk/commands/fix.py
+++ b/mdk/commands/fix.py
@@ -73,7 +73,7 @@ class FixCommand(Command):
 
         stablebranch = M.get('stablebranch')
         masterbranch = ''
-        if stablebranch in ['master', 'main']:
+        if stablebranch in ['main']:
             # Generate a branch name for master to check later whether there's already an existing working branch.
             masterbranch = M.generateBranchName(args.issue, args.suffix, 'master')
 

--- a/mdk/commands/plugin.py
+++ b/mdk/commands/plugin.py
@@ -222,7 +222,7 @@ class PluginCommand(Command):
             return False
 
         branch = M.get('branch')
-        if branch in ['master', 'main']:
+        if branch in ['main']:
             branch = C.get('masterBranch')
         branch = int(branch)
 

--- a/mdk/commands/rebase.py
+++ b/mdk/commands/rebase.py
@@ -160,7 +160,7 @@ class RebaseCommand(Command):
             # Looping over each issue to rebase
             for issue in issues:
                 branch = M.generateBranchName(issue, suffix=args.suffix)
-                if M.get('stablebranch') in ['master', 'main']:
+                if M.get('stablebranch') in ['main']:
                     masterbranch = M.generateBranchName(issue, args.suffix, 'master')
                     if M.git().hasBranch(masterbranch):
                         prompt = (

--- a/mdk/moodle.py
+++ b/mdk/moodle.py
@@ -628,7 +628,7 @@ class Moodle(object):
                 self.version['branch'] = 'main'
 
             # Stable branch
-            self.version['stablebranch'] = stableBranch(self.version['branch'], self.git())
+            self.version['stablebranch'] = stableBranch(self.version['branch'])
 
             # Integration or stable?
             self.version['integration'] = self.isIntegration()

--- a/mdk/tools.py
+++ b/mdk/tools.py
@@ -230,8 +230,8 @@ def natural_sort_key(s, _nsre=re.compile('([0-9]+)')):
     return [int(text) if text.isdigit() else text.lower() for text in _nsre.split(s)]
 
 
-def stableBranch(version, git=None):
-    if version in ['master', 'main']:
+def stableBranch(version):
+    if version in ['main']:
         return 'main'
     return 'MOODLE_%d_STABLE' % int(version)
 
@@ -240,7 +240,7 @@ def version_options():
     return ([str(x) for x in range(13, 40)]
             + [str(x) for x in range(310, 312)]
             + [str(x) for x in range(400, C.get('masterBranch'))]
-            + ['master', 'main'])
+            + ['main'])
 
 class ProcessInThread(threading.Thread):
     """Executes a process in a separate thread"""

--- a/mdk/workplace.py
+++ b/mdk/workplace.py
@@ -130,7 +130,7 @@ class Workplace(object):
         # Update the cached clones.
         self.updateCachedClones(stable=not integration, integration=integration, verbose=False)
 
-        branch = stableBranch(version, git.Git(self.getCachedRemote(integration), C.get('git')))
+        branch = stableBranch(version)
 
         useCacheAsUpstream = C.get('useCacheAsUpstreamRemote')
         cloneAsShared = useCacheAsUpstream and C.get('useCacheAsSharedClone')


### PR DESCRIPTION
The `master` branch will be removed on 12 August 2024
- Remove from version options
- No need to sync `master` with `main` during `update`.

`doctor --masterbranch` and other `master`-related settings are left untouched and can be dealt with separately.