### PR TITLE
Remove fallback logic to `master`

### DIFF
--- a/mdk/tools.py
+++ b/mdk/tools.py
@@ -232,10 +232,6 @@ def natural_sort_key(s, _nsre=re.compile('([0-9]+)')):
 
 def stableBranch(version, git=None):
     if version in ['master', 'main']:
-        if git is not None and not git.hasBranch('main', C.get('upstreamRemote')):
-            # Fall back to master if main is not yet available.
-            logging.info('The main branch has not been found, using master instead.')
-            return 'master'
         return 'main'
     return 'MOODLE_%d_STABLE' % int(version)
 


### PR DESCRIPTION
With the `master` branch gone, there is no need to fall back to it. Otherwise, errors will be encountered, especially when MDK is freshly installed.

For example:
```bash
$ mdk create -t
Creating instance integration_main...
Cloning integration repository into cache...
The main branch has not been found, using master instead.
Cloning repository...
Checking out branch...
Error creating integration_main:
  This is not a Git repository
Traceback (most recent call last):
  File "/home/moodle/apps/mdk/mdk/commands/create.py", line 172, in do
    M = self.Wp.create(**kwargs)
  File "/home/moodle/apps/mdk/mdk/workplace.py", line 181, in create
    repo.delRemote('origin')
  File "/home/moodle/apps/mdk/mdk/git.py", line 116, in delRemote
    result = self.execute(cmd)
  File "/home/moodle/apps/mdk/mdk/git.py", line 124, in execute
    raise Exception('This is not a Git repository')
Exception: This is not a Git repository

Process complete!
```