### PR TITLE
Include setuptools to support pipx installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ psycopg2>=2.4.5
 requests>2.3.0
 watchdog>=0.8.0
 pyodbc>=4.0.21
+setuptools


### PR DESCRIPTION
I've been using pipx to install mdk from source, and the install is broken due to missing setuptools in the list of requirements.

```
➜  moodle git:(MDL-83424-main) mdk push
ModuleNotFoundError: No module named 'pkg_resources'
  File "/Users/nicols/.local/pipx/venvs/moodle-sdk/lib/python3.12/site-packages/mdk/__main__.py", line 115, in main
    Runner.run(args, prog='%s %s' % (os.path.basename(sys.argv[0]), cmd))
  File "/Users/nicols/.local/pipx/venvs/moodle-sdk/lib/python3.12/site-packages/mdk/command.py", line 147, in run
    self.command.run(args)
  File "/Users/nicols/.local/pipx/venvs/moodle-sdk/lib/python3.12/site-packages/mdk/commands/push.py", line 106, in run
    M = self.Wp.resolve(args.name)
        ^^^^^^^
  File "/Users/nicols/.local/pipx/venvs/moodle-sdk/lib/python3.12/site-packages/mdk/command.py", line 76, in Wp
    from .workplace import Workplace
  File "/Users/nicols/.local/pipx/venvs/moodle-sdk/lib/python3.12/site-packages/mdk/workplace.py", line 33, in <module>
    from . import moodle
  File "/Users/nicols/.local/pipx/venvs/moodle-sdk/lib/python3.12/site-packages/mdk/moodle.py", line 42, in <module>
    from .scripts import Scripts
  File "/Users/nicols/.local/pipx/venvs/moodle-sdk/lib/python3.12/site-packages/mdk/scripts.py", line 30, in <module>
    from pkg_resources import resource_filename
```

Including setuptools in the requirements means that the pyenv virtual environment includes pkg_resources.