### PR TITLE
Issue 245: correct number of placeholders for expected strings

### DIFF
--- a/mdk/fetch.py
+++ b/mdk/fetch.py
@@ -223,7 +223,7 @@ class FetchTracker(Fetch):
 
         ref = issueInfo.get('branches').get(str(branch), None)
         if not ref:
-            raise FetchTrackerBranchException('Could not find branch info on %s' % (str(branch), mdl))
+            raise FetchTrackerBranchException('Could not find branch info on %s, %s' % (str(branch), mdl))
 
         self.setRepo(repo)
         self.setRef(ref.get('branch'))


### PR DESCRIPTION
This is a fix for https://github.com/FMCorz/mdk/issues/245:

The exception is looking for 1 argument but receives 2.