### PR TITLE
Issue 247: fixed version_options() syntax

### DIFF
--- a/mdk/commands/rebase.py
+++ b/mdk/commands/rebase.py
@@ -52,7 +52,7 @@ class RebaseCommand(Command):
             (
                 ['-v', '--versions'],
                 {
-                    'choices': 'version_options(),,',
+                    'choices': version_options(),
                     'help': 'versions to rebase the issues on. Ignored if names is set.',
                     'metavar': 'version',
                     'nargs': '+',


### PR DESCRIPTION
This is a fix for issue #247:

The function call was surrounded by quotes and made into a string. 