### PR TITLE
Support for scripts with MDL-83424

### DIFF
--- a/mdk/moodle.py
+++ b/mdk/moodle.py
@@ -194,9 +194,22 @@ class Moodle(object):
         # Ensure path is relative.
         if cli.startswith(self.path):
             cli = cli[len(self.path):]
+
         cli = cli.lstrip('/')
 
+        branch = self.get('branch')
+
+        if self.branch_compare(501, '>='):
+            # From Moodle 5.1 onwards, Moodle moves to a public directory.
+            # Initially all content is moved there, but it will gradually move out.
+            if not self.container.exists(Path(cli)):
+                if not cli.startswith('public') and self.container.exists(Path('public/version.php')):
+                    if self.container.exists(Path('public', cli)):
+                        # If the version.php is in the public directory, we need to run the script from there.
+                        cli = os.path.join('public', cli)
+
         if not self.container.exists(Path(cli)):
+            # If the version.php is in the public directory, we need to run the script from there.
             raise Exception('Could not find script to call')
 
         args = args or []

--- a/mdk/scripts/makecourse.sh
+++ b/mdk/scripts/makecourse.sh
@@ -9,6 +9,10 @@ FULLNAME="Moodle Development $I"
 SIZE="S"
 CLI="admin/tool/generator/cli/maketestcourse.php"
 
+if [ -d "public" ] && [ -e "public/$CLI" ]; then
+    CLI="public/$CLI"
+fi
+
 if [ ! -e "$CLI" ]; then
     echo "Cannot create a course: the CLI script to create test courses could not be found."
     exit 1


### PR DESCRIPTION
With MDL-83424 most scripts are in the same location within the public directory.

This will likely change gradually over time and when MDL-85847 lands, but at the moment this change is required to get phpunit and the scripts to run properly.