### PR TITLE
Update gt to link to the moodle root

### DIFF
--- a/extra/goto_instance
+++ b/extra/goto_instance
@@ -35,8 +35,8 @@
 
 # Go to instance directory.
 function gt() {
-    DIR=`mdk config show dirs.www`
-    eval DIR="$DIR/$1"
+    DIR=`mdk config show dirs.storage`
+    eval DIR="$DIR/$1/moodle"
     if [[ ! -d $DIR ]]; then
         echo "Could not resolve path"
         return


### PR DESCRIPTION
I am informed that some people create their own symlink for Moodle to link straight to the `public` directory. As a result though the `gt` command points to the wrong place.

Rather than having `gt` point to the public directory, this changes it to point to the storage directory behind the normal symlink.