### PR TITLE
Symlink the Moodle public directory

### DIFF
--- a/mdk/moodle.py
+++ b/mdk/moodle.py
@@ -581,6 +581,10 @@ class Moodle(object):
         raise Exception('This does not appear to be a Moodle instance')
 
     @staticmethod
+    def getRootPath(path):
+        return os.path.dirname(Moodle.getVersionPath(path))
+
+    @staticmethod
     def isInstance(path):
         """Check whether the path is a Moodle web directory"""
         version = Moodle.getVersionPath(path)

--- a/mdk/workplace.py
+++ b/mdk/workplace.py
@@ -154,13 +154,15 @@ class Workplace(object):
             f'{"--shared" if cloneAsShared else ""} {repository} {wwwDir}'
         )
 
+        linkSource = moodle.Moodle.getRootPath(wwwDir)
+
         # Symbolic link
         if os.path.islink(linkDir):
             os.remove(linkDir)
         if os.path.isfile(linkDir) or os.path.isdir(linkDir):  # No elif!
-            logging.warning('Could not create symbolic link. Please manually create: ln -s %s %s' % (wwwDir, linkDir))
+            logging.warning('Could not create symbolic link. Please manually create: ln -s %s %s' % (linkSource, linkDir))
         else:
-            os.symlink(wwwDir, linkDir)
+            os.symlink(linkSource, linkDir)
 
         # Symlink to extra.
         if os.path.isfile(extraLinkDir) or os.path.isdir(extraLinkDir):


### PR DESCRIPTION
From MDL-83424 in Moodle 5.1 we have a `public` directory.

Rather than web service configuration you can symlink direct to the `[sitename]/moodle/public` directory for a much simpler web server configuration.