### PR TITLE
Fix precheck failing with RemoteDisconnected while polling the CI

### DIFF
--- a/mdk/ci.py
+++ b/mdk/ci.py
@@ -64,7 +64,8 @@ class CI(object):
         logger.setLevel(logging.WARNING)
 
         # Loads the jenkins object.
-        self._jenkins = jenkins.Jenkins(self.url, requester=CrumbRequester(baseurl=self.url))
+        # max_retries: the server drops idle connections between polls, reconnect.
+        self._jenkins = jenkins.Jenkins(self.url, requester=CrumbRequester(baseurl=self.url, max_retries=3))
 
     def precheckRemoteBranch(self, remote, branch, integrateto, issue=None):
         """Runs the precheck job and returns the outcome"""


### PR DESCRIPTION
integration.moodle.org closes idle keep-alive connections in under five seconds, but our jenkinsapi polling loops sleep at least that long between requests. With requests defaulting to max_retries=0, the stale socket raised a hard ConnectionError instead of reconnecting.

Requester mounts a retrying adapter when given max_retries; we just never passed it.